### PR TITLE
call req.setHeaders() before calling req.write()

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -293,8 +293,8 @@ Message.prototype.bind = function (options, body) {
       req.write(body);
 
     } else {
-      req.write(JSON.stringify(body));
       req.setHeader('Content-Type', 'application/json');
+      req.write(JSON.stringify(body));
     }
   }
 


### PR DESCRIPTION
prevents error "can't set headers after they are sent"
